### PR TITLE
chore: adjust module names to match package name.

### DIFF
--- a/lib/strategy.ex
+++ b/lib/strategy.ex
@@ -1,4 +1,4 @@
-defmodule Cluster.Strategy.Postgres do
+defmodule LibclusterPostgres.Strategy do
   @moduledoc """
   A libcluster strategy that uses Postgres LISTEN/NOTIFY to determine the cluster topology.
 

--- a/test/strategy_test.exs
+++ b/test/strategy_test.exs
@@ -1,4 +1,4 @@
-defmodule Cluster.Strategy.PostgresTest do
+defmodule LibclusterPostgres.StrategyTest do
   use ExUnit.Case
 
   alias Postgrex.Notifications
@@ -17,7 +17,7 @@ defmodule Cluster.Strategy.PostgresTest do
     verify_conn_notification = start_supervised!({Notifications, @config})
     Notifications.listen(verify_conn_notification, @config[:channel_name])
 
-    topologies = [postgres: [strategy: Cluster.Strategy.Postgres, config: @config]]
+    topologies = [postgres: [strategy: LibclusterPostgres.Strategy, config: @config]]
     start_supervised!({Cluster.Supervisor, [topologies]})
 
     channel_name = @config[:channel_name]


### PR DESCRIPTION
This adjusts module naming to match the library name with the library namespace.