### PR TITLE
Support `ssl` and `ssl_opts` connection options

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ config :libcluster,
           database: "postgres",
           port: 5432,
           parameters: [],
+          # optional, defaults to false
+          ssl: true,
+          # optional, please refer to the Postgrex docs
+          ssl_opts: nil,
           # optional, defaults to node cookie
           channel_name: "cluster"
       ],

--- a/lib/strategy.ex
+++ b/lib/strategy.ex
@@ -32,6 +32,8 @@ defmodule LibclusterPostgres.Strategy do
       password: Keyword.fetch!(state.config, :password),
       database: Keyword.fetch!(state.config, :database),
       port: Keyword.fetch!(state.config, :port),
+      ssl: Keyword.get(state.config, :ssl),
+      ssl_opts: Keyword.get(state.config, :ssl_opts),
       parameters: Keyword.fetch!(state.config, :parameters),
       channel_name: channel_name
     ]

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule LibclusterPostgres.MixProject do
     [
       name: "libcluster_postgres",
       app: :libcluster_postgres,
-      version: "0.1.1",
+      version: "0.1.2",
       elixir: "~> 1.14",
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
## What kind of change does this PR introduce?

This adds support for the `ssl` and `ssl_opts` Postgrex connection options.

## What is the current behavior?

If a custom SSL cert is required then the connection will fail.

## What is the new behavior?

Custom SSL certs can now be configured and used.

## Additional context

Crunchy Bridge provides customers their own SSL PEM, and SSL is enforced with all db connections. This PR addresses issues with SSL details not being passed to Postgrex.
