### PR TITLE
Support socket options

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ config :libcluster,
           ssl: true,
           # optional, please refer to the Postgrex docs
           ssl_opts: nil,
+          # optional, please refer to the Postgrex docs
+          socket_options: nil,
           # optional, defaults to node cookie
           channel_name: "cluster"
       ],

--- a/lib/strategy.ex
+++ b/lib/strategy.ex
@@ -34,6 +34,7 @@ defmodule LibclusterPostgres.Strategy do
       port: Keyword.fetch!(state.config, :port),
       ssl: Keyword.get(state.config, :ssl),
       ssl_opts: Keyword.get(state.config, :ssl_opts),
+      socket_options: Keyword.get(state.config, :socket_options, []),
       parameters: Keyword.fetch!(state.config, :parameters),
       channel_name: channel_name
     ]


### PR DESCRIPTION
## What kind of change does this PR introduce?

Adds support for `socket_options` when initializing `Postgrex`. This is required if the database is accessed through a IPV6 instead of IPV4. 

## What is the current behavior?

It is not possible to connect to IPV6 databases through `libcluster_postgres`. 

## What is the new behavior?

It is now possible to specify `socket_options: [:inet6]` inside the postgres config to connect to IPV6 database. 

## Additional context

NA
