### PR TITLE
fix: postgrex ssl opts

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,8 @@ config :libcluster,
           port: 5432,
           # optional, connection parameters. Defaults to []
           parameters: [],
-          # optional, defaults to false
+          # optional, defaults to false. Refer to Postgrex docs
           ssl: true,
-          # optional, please refer to the Postgrex docs
-          ssl_opts: nil,
           # optional, please refer to the Postgrex docs
           socket_options: nil,
           # optional, defaults to node cookie
@@ -52,6 +50,8 @@ config :libcluster,
           channel_name: "cluster",
           # optional, heartbeat interval in ms. defaults to 5s
           heartbeat_interval: 10_000
+          # optional, auto-reconnect to notifications, defaults to true
+          auto_reconnect: false
       ],
     ]
   ]

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ config :libcluster,
           # optional, connection parameters. Defaults to []
           parameters: [],
           # optional, defaults to false. Refer to Postgrex docs
+          # as of v0.18 postgrex, accepts `true` or a keyword list of options
           ssl: true,
           # optional, please refer to the Postgrex docs
           socket_options: nil,

--- a/lib/strategy.ex
+++ b/lib/strategy.ex
@@ -26,9 +26,11 @@ defmodule LibclusterPostgres.Strategy do
   def init([state]) do
     channel_name = Keyword.get(state.config, :channel_name, clean_cookie(Node.get_cookie()))
 
-    ssl = if ssl_value = Keyword.get(state.config, :ssl) do
-      Keyword.get(state.config, :ssl_opts) || ssl_value
-    end
+    ssl =
+      if ssl_value = Keyword.get(state.config, :ssl) do
+        Keyword.get(state.config, :ssl_opts) || ssl_value
+      end
+
     opts = [
       hostname: Keyword.fetch!(state.config, :hostname),
       username: Keyword.fetch!(state.config, :username),

--- a/lib/strategy.ex
+++ b/lib/strategy.ex
@@ -26,17 +26,20 @@ defmodule LibclusterPostgres.Strategy do
   def init([state]) do
     channel_name = Keyword.get(state.config, :channel_name, clean_cookie(Node.get_cookie()))
 
+    ssl = if ssl_value = Keyword.get(state.config, :ssl) do
+      Keyword.get(state.config, :ssl_opts) || ssl_value
+    end
     opts = [
       hostname: Keyword.fetch!(state.config, :hostname),
       username: Keyword.fetch!(state.config, :username),
       password: Keyword.fetch!(state.config, :password),
       database: Keyword.fetch!(state.config, :database),
       port: Keyword.fetch!(state.config, :port),
-      ssl: Keyword.get(state.config, :ssl),
-      ssl_opts: Keyword.get(state.config, :ssl_opts),
+      ssl: ssl,
       socket_options: Keyword.get(state.config, :socket_options, []),
       parameters: Keyword.get(state.config, :parameters, []),
-      channel_name: channel_name
+      channel_name: channel_name,
+      auto_reconnect: Keyword.get(state.config, :auto_reconnect, true)
     ]
 
     config =

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule LibclusterPostgres.MixProject do
     [
       name: "libcluster_postgres",
       app: :libcluster_postgres,
-      version: "0.1.3",
+      version: "0.2.0",
       elixir: "~> 1.14",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
@@ -27,7 +27,7 @@ defmodule LibclusterPostgres.MixProject do
   defp deps do
     [
       {:libcluster, "~> 3.3"},
-      {:postgrex, ">= 0.0.0"},
+      {:postgrex, ">= 0.18.0"},
       {:ex_doc, ">= 0.0.0", only: :dev, runtime: false}
     ]
   end


### PR DESCRIPTION
Removes :ssl_opts for postgrex which is now removed after v0.18 postgrex. 

Adds in :auto_reconnect option for notifications from channel.

Performs minor version bump.

