### PR TITLE
fix: add auto_reconnect to the Postgrex.Notifications

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule LibclusterPostgres.MixProject do
     [
       name: "libcluster_postgres",
       app: :libcluster_postgres,
-      version: "0.1.3",
+      version: "0.1.4",
       elixir: "~> 1.14",
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
If Postgres is not available at the time of startup, `Postgrex.Notifications.start_link` will kill the strategy process each time the supervisor restarts it, until all retries are exhausted.

https://github.com/supabase/libcluster_postgres/blob/82e36ab33ec0d83c1f7ded57ac977f9ba1079654/lib/strategy.ex#L60

This PR fixes this behavior by starting `Postgrex.Notifications` with the `:auto_reconnect` option. This prevents the process from killing and allows it to keep retrying connection attempts in the background. Once Postgres becomes available again, the process will cast the node name into the cluster.